### PR TITLE
Feature/load filepond from cdn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3612,9 +3612,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -5165,9 +5165,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/src/forms/component/image-upload.jsx
+++ b/src/forms/component/image-upload.jsx
@@ -1,24 +1,16 @@
-import { FilePond, registerPlugin } from "react-filepond";
-// TODO: dit gaat mis omdat webpack in die css iets invalids vindt
-// import "filepond/dist/filepond.min.css";
-import 'filepond-polyfill';
-import FilepondPluginImagePreview from 'filepond-plugin-image-preview';
-import FilepondPluginFileValidateType from 'filepond-plugin-file-validate-type';
-import FilepondPluginFileValidateSize from 'filepond-plugin-file-validate-size';
-import FilepondPluginFilePoster from 'filepond-plugin-file-poster';
+'use strict';
 
 import OpenStadComponentDefaultInput from './default-input.jsx';
 
-// Register the plugins
-registerPlugin(FilepondPluginImagePreview, FilepondPluginFileValidateType, FilepondPluginFileValidateSize, FilepondPluginFilePoster);
-
-export default class OpenStadComponentImageUpload extends OpenStadComponentDefaultInput {
+export default class OpenStadComponentSelect extends OpenStadComponentDefaultInput {
 
   constructor(props) {
 
     super(props, {
       name: 'image',
       allowMultiple: false,
+			maxFileSize: '8mb',
+			maxFiles: 5,
 			image: {
         server: {
 				  process: '/image',
@@ -53,6 +45,41 @@ export default class OpenStadComponentImageUpload extends OpenStadComponentDefau
 
   }
 
+	componentDidMount(prevProps, prevState) {
+    // filepond files
+		this._loadedFiles = 0;
+    this.files = [
+      "https://unpkg.com/filepond/dist/filepond.js",
+      "https://unpkg.com/filepond-polyfill/dist/filepond-polyfill.js",
+      "https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js",
+      "https://unpkg.com/filepond-plugin-file-validate-type/dist/filepond-plugin-file-validate-type.js",
+      "https://unpkg.com/filepond-plugin-file-validate-size/dist/filepond-plugin-file-validate-size.js",
+      "https://unpkg.com/filepond-plugin-file-poster/dist/filepond-plugin-file-poster.js",
+    ];
+    this.loadNextFile();
+  }
+  
+  loadNextFile() {
+    var self = this;
+    var file = self.files[self._loadedFiles];
+    if (file) {
+			let element;
+			element = document.createElement('script');
+			element.src = file;
+			element.async = true;
+			if (element) {
+				element.onload = function() {
+          self.loadNextFile();
+				}
+				document.body.appendChild(element);
+			}
+    }
+		if (self._loadedFiles == self.files.length) {
+      self.fileUploaderInit()
+    }
+		self._loadedFiles++;
+  }
+
   validate() {
     let isValid = true;
 		if ( this.imageuploader && this.imageuploader.getFiles ) {
@@ -66,92 +93,138 @@ export default class OpenStadComponentImageUpload extends OpenStadComponentDefau
     return isValid;
   }
 
-  init() {
-  }
+  fileUploaderInit() {
 
-  updateUploadedFiles({ addFile, removeFile, next }) {
-		if ( this.imageuploader && this.imageuploader.getFiles ) {
-      let current = this.imageuploader.getFiles();
-      if (removeFile) {
-        current = current.filter(file => file.serverId != removeFile.serverId);
-      }
-      this.setState({ uploadedFiles: current.map(fileItem => fileItem.file) }, () => {
-        if (next) next(current);
-      })
-    }
-  }
-
-  updateValue(files) {
-    let self = this;
-    let value = [];
-    var asJson = self.config.as && self.config.as == 'json';
-		files.forEach((image) => {
-			try {
-				var serverId = typeof image.serverId == 'string' ? JSON.parse(image.serverId) : image.serverId;
-				value.push( asJson ? { "src": serverId.url } : serverId.url  )
-			} catch(err) { console.log(err) }
-		});
-    self.handleOnChange({name: self.config.name, value})
-  }
-
-  render() {
     let self = this;
 
-    return (
-    <FilePond
-
-      ref={ref => (this.imageuploader = ref)}
-      files={this.state.uploadedFiles}
-
-      oninit={self.init}
-      onprocessfile={( err, file ) => self.updateUploadedFiles({ addFile: file, next: files => self.updateValue(files) })}
-      onremovefile={( err, file ) => self.updateUploadedFiles({ removeFile: file, next: files => self.updateValue(files) })}
-        
-      name="image"
-      server={this.config.image.server.process}
-      allowMultiple={this.config.allowMultiple}
+		var containerElement = document.querySelector('.osc-image-upload-container');
+		if (containerElement) {
+			FilePond.registerPlugin(FilePondPluginImagePreview);
+			FilePond.registerPlugin(FilePondPluginFileValidateSize);
+			FilePond.registerPlugin(FilePondPluginFileValidateType);
+			FilePond.registerPlugin(FilePondPluginFilePoster);
       
-      // todo: maak dit allemaal configurabel
-			acceptedFileTypes={['image/*']}
-			allowFileSizeValidation="true"
-      allowReorder={true}
-      styleItemPanelAspectRatio="1"
-			maxFileSize="8mb"
-			maxFiles="5"
-			allowBrowse="true"
-			imageResizeTargetWidth="80"
-			imageResizeTargetHeight="80"
-			imageCropAspectRatio="16:9"
-			labelIdle="Sleep afbeelding(en) naar deze plek of <span class='filepond--label-action'>KLIK HIER</span>"
-			labelInvalidField="Field contains invalid files"
-			labelFileWaitingForSize="Wachtend op grootte"
-			labelFileSizeNotAvailable="Grootte niet beschikbaar"
-			labelFileCountSingular="Bestand in lijst"
-			labelFileCountPlural="Bestanden in lijst"
-			labelFileLoading="Laden"
-			labelFileAdded="Toegevoegd"
-			labelFileLoadError="Fout bij het uploaden"
-			labelFileRemoved="Verwijderd"
-			labelFileRemoveError="Fout bij het verwijderen"
-			labelFileProcessing="Laden"
-			labelFileProcessingComplete="Afbeelding geladen"
-			labelFileProcessingAborted="Upload cancelled"
-			labelFileProcessingError="Error during upload"
-			labelFileProcessingRevertError="Error during revert"
-			labelTapToCancel="tap to cancel"
-			labelTapToRetry="tap to retry"
-			labelTapToUndo="tap to undo"
-			labelButtonRemoveItem="Verwijderen"
-			labelButtonAbortItemLoad="Abort"
-			labelButtonRetryItemLoad="Retry"
-			labelButtonAbortItemProcessing="Verwijder"
-			labelButtonUndoItemProcessing="Undo"
-			labelButtonRetryItemProcessing="Retry"
-			labelButtonProcessItem="Upload"
+			var filePondSettings = {
 
-    />);
+				files: this.state.uploadedFiles,
+
+				server: {
+					process: this.config.image.server.process,
+					fetch: this.config.image.server.fetch,
+				},
+
+        allowMultiple: this.config.allowMultiple,
+				maxFileSize: this.config.maxFileSize,
+				maxFiles: this.config.maxFiles,
+
+        // todo: maak dit allemaal configurabel
+				acceptedFileTypes: ['image/*'], // set allowed file types with mime types
+				allowFileSizeValidation: true,
+        allowReorder: true,
+        styleItemPanelAspectRatio: 1,
+				name: 'image',
+				allowBrowse: true,
+				imageResizeTargetWidth: 80,
+				imageResizeTargetHeight: 80,
+				imageCropAspectRatio: '1:1',
+				labelIdle: "Sleep afbeelding(en) naar deze plek of <span class='filepond--label-action'>KLIK HIER</span>",
+				labelInvalidField: "Field contains invalid files",
+				labelFileWaitingForSize: "Wachtend op grootte",
+				labelFileSizeNotAvailable: "Grootte niet beschikbaar",
+				labelFileCountSingular: "Bestand in lijst",
+				labelFileCountPlural: "Bestanden in lijst",
+				labelFileLoading: "Laden",
+				labelFileAdded: "Toegevoegd", // assistive only
+				labelFileLoadError: "Fout bij het uploaden",
+				labelFileRemoved: "Verwijderd", // assistive only
+				labelFileRemoveError: "Fout bij het verwijderen",
+				labelFileProcessing: "Laden",
+				labelFileProcessingComplete: "Afbeelding geladen",
+				labelFileProcessingAborted: "Upload cancelled",
+				labelFileProcessingError: "Error during upload",
+				labelFileProcessingRevertError: "Error during revert",
+				labelTapToCancel: "tap to cancel",
+				labelTapToRetry: "tap to retry",
+				labelTapToUndo: "tap to undo",
+				labelButtonRemoveItem: "Verwijderen",
+				labelButtonAbortItemLoad: "Abort",
+				labelButtonRetryItemLoad: "Retry",
+				labelButtonAbortItemProcessing: "Verwijder",
+				labelButtonUndoItemProcessing: "Undo",
+				labelButtonRetryItemProcessing: "Retry",
+				labelButtonProcessItem: "Upload"
+			}
+
+      self.imageuploader = FilePond.create(containerElement, filePondSettings);
+			var sortableInstance;
+			var pondEl = document.querySelector('.filepond--root');
+
+      // tmp
+      //self.state.value = ["https://image-server.staging.openstadsdeel.nl/image/85ef5669d9a5db2f0ec2adb6310620be"]
+      //self.props.handleFieldChange(self.props.name, self.state.value )
+
+			document.querySelector('.filepond--root').addEventListener('FilePond:processfile', e => {
+				if (e.detail && e.detail.error) {
+					console.log('Error uploding file: ', e.detail);
+				}
+				self.fileUploaderUpdateCurrentInput()
+			});
+			
+			document.querySelector('.filepond--root').addEventListener('FilePond:removefile', e => {
+				if (e.detail && e.detail.error) {
+					console.log('Error uploding file: ', e.detail);
+				}
+				self.fileUploaderUpdateCurrentInput()
+			});
+
+			if (self.state.formfields) {
+				self.imageuploader.addFiles(self.state.formfields.images)
+			}
+
+		}
+
+	}
+
+  fileUploaderUpdateCurrentInput() {
+    let self = this;
+		self.state.value = [];
+		if ( this.imageuploader && this.imageuploader.getFiles ) {
+			var images = this.imageuploader.getFiles();
+      var asJson = self.config.as && self.config.as == 'json';
+			images.forEach((image) => {
+				try {
+					var serverId = typeof image.serverId == 'string' ? JSON.parse(image.serverId) : image.serverId;
+					self.state.value.push( asJson ? { "src": serverId.url } : serverId.url  )
+				} catch(err) { console.log(err) }
+			});
+		}
+    self.props.onChange({name: self.config.name, value: self.state.value})
+	}
+
+  fileUploaderUploaderAddImages(images) {
+    let self = this;
+		if (this.imageuploader) {
+			this.imageuploader.addFiles(images)
+		}
+	}
+
+	render() {
+
+		let self = this;
+
+    let errorHTML = null;
+    if (self.state.error) {
+      errorHTML = (<div className="osc-form-error osc-form-field-error">Je hebt nog geen afbeelding geupload</div>)
+    }
+    
+    return (
+			<div className="osc-image-upload-container">
+				<input type="file" className="imageUploader-gebiedstool filepond-gebiedstool"/>
+        {errorHTML}
+		  </div>
+    );
 
   }
-}
 
+}
 


### PR DESCRIPTION
# Description

The form module contains an image upload formfield/ Thsi field is cretaed using the Filepond library.

This library has a React version; that version was used. The problem here is that every module that uses forms is now ca. 150KB larger than it is without.

This change therefore proposes to revert back to the 'load-lib-from-cdn' version that was used before. The fileupload is less clean, but all compiled openstad-components libs are 150KB smaller.

I think this tradeoff is acceptable.

## Type of change

code improvement, i guess

## Documentation

n/a

## Tests

Local, staging, e2e
