### PR TITLE
Feature/add lazy loading of image upload

### DIFF
--- a/src/forms/component/form-field.jsx
+++ b/src/forms/component/form-field.jsx
@@ -1,6 +1,6 @@
 'use strict';
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import merge from 'merge';
 
 import OpenStadComponent from '../../component/index.jsx';
@@ -87,7 +87,11 @@ export default class OpenStadComponentFormField extends OpenStadComponent {
         break;
 
       case 'image-upload':
-        fieldHTML = <OpenStadComponentImageUpload config={self.config} value={ this.state.value } onChange={self.handleOnChange} ref={el => (self.input = el)}/>
+        fieldHTML =
+          <Suspense fallback={<div>Loading...</div>}>
+            <OpenStadComponentImageUpload config={self.config} value={ this.state.value } onChange={self.handleOnChange} ref={el => (self.input = el)}/>
+          </Suspense>
+
         break;
 
       case 'input-with-counter':

--- a/src/forms/component/form-field.jsx
+++ b/src/forms/component/form-field.jsx
@@ -1,10 +1,11 @@
 'use strict';
 
+import React from 'react';
 import merge from 'merge';
 
 import OpenStadComponent from '../../component/index.jsx';
 import OpenStadComponentHidden from './hidden.jsx';
-import OpenStadComponentImageUpload from './image-upload.jsx';
+const OpenStadComponentImageUpload = React.lazy(() => import('./image-upload.jsx'));
 import OpenStadComponentInputWithCounter from './input-with-counter.jsx';
 import OpenStadComponentRadios from './radios.jsx';
 import OpenStadComponentPostcode from './postcode.jsx';

--- a/src/forms/image-upload.jsx
+++ b/src/forms/image-upload.jsx
@@ -1,0 +1,13 @@
+// react
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+// import css to make sure it is generated in the result
+import './css/default.less';
+
+// the module
+import ImageUpload from './component/image-upload.jsx';
+export default {
+  ImageUpload,
+}
+

--- a/src/forms/index.jsx
+++ b/src/forms/index.jsx
@@ -14,7 +14,6 @@ import './css/default.less';
 import Form from './component/form.jsx';
 import FormField from './component/form-field.jsx';
 import Hidden from './component/hidden.jsx';
-import ImageUpload from './component/image-upload.jsx';
 import InputWithCounter from './component/input-with-counter.jsx';
 import Postcode from './component/postcode.jsx';
 import Radios from './component/radios.jsx';
@@ -26,7 +25,6 @@ export default {
   Form,
   FormField,
   Hidden,
-  ImageUpload,
   InputWithCounter,
   Postcode,
   Radios,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     'button': './src/button/index.jsx',
     'choices-guide': './src/choices-guide/index.jsx',
     'forms': './src/forms/index.jsx',
+    'forms-image-upload': './src/forms/image-upload.jsx',
     'idea-details': './src/idea-details/index.jsx',
     'ideas-overview': './src/ideas-overview/index.jsx',
     'idea-image': './src/image/index.jsx',


### PR DESCRIPTION
# Description

The form module contains an image upload formfield/ Thsi field is cretaed using the Filepond library.

This library has a React version; that version was used. The problem here is that every module that uses forms is now ca. 150KB larger than it is without.

To make sure this extra data is only loaded when necessary React.lazy is used.

## Type of change

code improvement

## Documentation

n/a

## Tests

Local
