### PR TITLE
Better true/false checks in choices-guide

### DIFF
--- a/src/choices-guide/component/edit/choices-guide-form.jsx
+++ b/src/choices-guide/component/edit/choices-guide-form.jsx
@@ -47,7 +47,7 @@ export default class ChoicesGuideForm extends OpenStadComponent {
 
     let moreConfigHTML = null;
 
-    if (config.isActive == "true") {
+    if (!!config.isActive != false && config.isActive != "false" && config.isActive != "0") {
 
       let requiredUserRoleConfigHTML = null;  
       if (config.submissionType == "form") {

--- a/src/choices-guide/component/question.jsx
+++ b/src/choices-guide/component/question.jsx
@@ -228,7 +228,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
         }
         let questionImageAHTML = null;
         let questionImageBHTML = null;
-        if (questionImageA && questionImageB) {
+        if (questionImageA && questionImageA.length && questionImageB && questionImageB.length) {
           questionImageAHTML = (
             <div className="osc-question-description-image-container osc-question-description-image-container-a">
               <div className="osc-question-description-label osc-question-description-label-a">{labelA}</div>


### PR DESCRIPTION
## Fixing a few issues in the Choices Guide.

**Issue**: submit settings are not always shown when they should

**Fix**: better check on isActive

**Issue**: after removing question images a white space is stille shown where the images were

**Fix**: better check on _do images exist_
